### PR TITLE
:arrow_down: Lower minimum required Ruby version to 3.2.7

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,8 @@ jobs:
       matrix:
         ruby:
           - '3.4.2'
+          - '3.3.7'
+          - '3.2.7'
 
     steps:
       - uses: actions/checkout@v4

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -7,7 +7,7 @@ AllCops:
   - bin/**/*
   - vendor/**/*
   ExtraDetails: true
-  TargetRubyVersion: 3.4
+  TargetRubyVersion: 3.2
   UseCache: true
 inherit_mode:
   merge:

--- a/Rakefile
+++ b/Rakefile
@@ -4,6 +4,6 @@ require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 
 RSpec::Core::RakeTask.new(:spec)
-Dir["lib/tasks/*.rake"].each { load it }
+Dir["lib/tasks/*.rake"].each {|file| load file }
 
 task default: %i[spec rubocop]

--- a/gemoji-cli.gemspec
+++ b/gemoji-cli.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
 
   spec.homepage = "https://github.com/sakuro/gemoji-cli"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.4.2"
+  spec.required_ruby_version = ">= 3.2.7"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "#{spec.homepage}.git"

--- a/mise.toml
+++ b/mise.toml
@@ -1,2 +1,5 @@
 [env]
 _.path = ["bin", "exe"]
+
+[tools]
+ruby = "3.2.7"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 require "gemoji/cli"
-Dir.glob("spec/support/**/*.rb").each { load it }
+Dir.glob("spec/support/**/*.rb").each {|file| load file }
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
- Update required_ruby_version in gemspec to >= 3.2.7
- Update RuboCop target version to 3.2
- Add Ruby 3.2.7 and 3.3.7 to CI matrix
- Set Ruby 3.2.7 in mise.toml as minimum supported version