### PR TITLE
:arrow_up: Bump version to 1.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 ## [Unreleased]
 
+## [1.1.0] - 2025-03-06
+- Loosen version requirement of ruby to 3.2.7
+
 ## [1.0.0] - 2025-02-24
 - Initial release

--- a/lib/gemoji/cli/version.rb
+++ b/lib/gemoji/cli/version.rb
@@ -2,7 +2,7 @@
 
 module Gemoji
   module CLI
-    VERSION = "1.0.0"
+    VERSION = "1.1.0"
     public_constant :VERSION
   end
 end


### PR DESCRIPTION

- Loosen version requirement of ruby to 3.2.7
