### PR TITLE
:wrench: Fix gem path handling for hyphenated gem names

### DIFF
--- a/.github/workflows/release-preparation.yml
+++ b/.github/workflows/release-preparation.yml
@@ -36,7 +36,9 @@ jobs:
 
     - name: Update version file
       run: |
-        sed -i 's/VERSION = ".*"/VERSION = "${{ github.event.inputs.version }}"/' lib/${{ env.GEM_NAME }}/version.rb
+        GEM_PATH="${{ env.GEM_NAME }}"
+        GEM_PATH="${GEM_PATH//-//}"  # Convert hyphens to slashes for path
+        sed -i 's/VERSION = ".*"/VERSION = "${{ github.event.inputs.version }}"/' "lib/$GEM_PATH/version.rb"
 
     - name: Update CHANGELOG.md
       run: |
@@ -51,7 +53,9 @@ jobs:
 
     - name: Commit changes
       run: |
-        git add lib/${{ env.GEM_NAME }}/version.rb CHANGELOG.md
+        GEM_PATH="${{ env.GEM_NAME }}"
+        GEM_PATH="${GEM_PATH//-//}"  # Convert hyphens to slashes for path
+        git add "lib/$GEM_PATH/version.rb" CHANGELOG.md
         git commit -m "$(cat <<'EOF'
         :bookmark: Prepare release v${{ github.event.inputs.version }}
 

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -48,7 +48,9 @@ jobs:
     - name: Verify version consistency
       run: |
         # Check if version in file matches branch
-        FILE_VERSION=$(grep 'VERSION = ' lib/${{ env.GEM_NAME }}/version.rb | sed 's/.*VERSION = "\(.*\)".*/\1/')
+        GEM_PATH="${{ env.GEM_NAME }}"
+        GEM_PATH="${GEM_PATH//-//}"  # Convert hyphens to slashes for path
+        FILE_VERSION=$(grep 'VERSION = ' "lib/$GEM_PATH/version.rb" | sed 's/.*VERSION = "\(.*\)".*/\1/')
         if [ "$FILE_VERSION" != "${{ steps.version.outputs.version }}" ]; then
           echo "❌ Error: Version mismatch. File: $FILE_VERSION, Expected: ${{ steps.version.outputs.version }}"
           exit 1


### PR DESCRIPTION
## Summary

Fix workflows to correctly reference `lib/gemoji/cli/version.rb` instead of `lib/gemoji-cli/version.rb`.

## Changes

- Convert hyphens to slashes using `${GEM_PATH//-//}` in bash
- Update release-preparation.yml (2 steps)
- Update release-validation.yml (1 step)

:robot: Generated with [Claude Code](https://claude.com/claude-code)
